### PR TITLE
Fixed IP address variable and instance role definition

### DIFF
--- a/modules/consul/02-consul-node-role.tf
+++ b/modules/consul/02-consul-node-role.tf
@@ -92,5 +92,5 @@ resource "aws_iam_policy_attachment" "consul-instance-leader-discovery" {
 //  Create a instance profile for the role.
 resource "aws_iam_instance_profile" "consul-instance-profile" {
   name  = "consul-instance-profile"
-  roles = ["${aws_iam_role.consul-instance-role.name}"]
+  role = "${aws_iam_role.consul-instance-role.name}"
 }

--- a/modules/consul/files/consul-node.sh
+++ b/modules/consul/files/consul-node.sh
@@ -77,14 +77,14 @@ done
 # Get my IP address, all IPs in the cluster, then just the 'other' IPs...
 IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
 mapfile -t ALL_IPS < <(cluster-ips)
-OTHER_IPS=( $${ALL_IPS[@]/${IP}/} )
+OTHER_IPS=( $${ALL_IPS[@]/$${IP}/} )
 echo "Instance IP is: $IP, Cluster IPs are: $${ALL_IPS[@]}, Other IPs are: $${OTHER_IPS[@]}"
 
 # Start the Consul server.
 docker run -d --net=host \
     --name=consul \
     consul agent -server -ui \
-    -bind="$IP" \
+    -bind="$$IP" \
     -client="0.0.0.0" \
     -retry-join="$${OTHER_IPS[0]}" -retry-join="$${OTHER_IPS[1]}" \
     -retry-join="$${OTHER_IPS[2]}" -retry-join="$${OTHER_IPS[3]}" \


### PR DESCRIPTION
With terraform v0.9.5 the IP variable requires to be escaped with a double $.
Also this MR fixes a warning about the instance role (which should be a single-value, not an array)

(thanks for the great tutorial)