### PR TITLE
Add terraform init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This will keep your AWS credentials in the `$HOME/.aws/credentials` file, which 
 The cluster is implemented as a [Terraform Module](https://www.terraform.io/docs/modules/index.html). To launch, just run:
 
 ```bash
+# Initialize terraform first time using
+terraform init
+
 # Create the module.
 terraform get
 


### PR DESCRIPTION
First time using terraform requires init

Before `terraform init`:
![screen shot 2018-02-26 at 11 56 47 am](https://user-images.githubusercontent.com/3058939/36692245-72082484-1aec-11e8-95bb-9895dd93b5f2.png)

After `terraform init`:
![screen shot 2018-02-26 at 11 57 20 am](https://user-images.githubusercontent.com/3058939/36692280-872638d8-1aec-11e8-815b-bff9f889f780.png)

[https://www.terraform.io/docs/commands/init.html](https://www.terraform.io/docs/commands/init.html): 

```wrap
The terraform init command is used to initialize a working directory containing Terraform configuration files.  
This is the first command that should be run after writing a new Terraform configuration or cloning an existing one from version control.  
It is safe to run this command multiple times.
```